### PR TITLE
Updated the logic to recognize 'true', 'yes', and '1' as valid values for synced patterns

### DIFF
--- a/includes/class-synced-patterns-loader.php
+++ b/includes/class-synced-patterns-loader.php
@@ -163,7 +163,8 @@ private static $synced_theme_patterns = [];
 			));
 
 			// if the pattern is not synced skip it 
-			if ($pattern_data['synced'] !== 'yes') {
+			$synced_value = strtolower(trim($pattern_data['synced']));
+			if (!in_array($synced_value, ['true', 'yes', '1'], true)) {
 				continue;
 			}
 


### PR DESCRIPTION
Updated the logic to recognize 'true', 'yes', and '1' as valid values for synced patterns, making the check more robust and match the [docs](https://github.com/Twenty-Bellows/synced-patterns-for-themes/blob/65938636f73412feb08526c2548908bf6c3f04ef/readme.md?plain=1#L35).